### PR TITLE
Add LinkButton

### DIFF
--- a/src/Button.imba
+++ b/src/Button.imba
@@ -53,9 +53,17 @@ export tag Button < button
 			if icon
 				<Icon[icon]>
 			if label
-				if href
-					<b> <a href=href uxa:md=label>
-				else
-					<b uxa:md=label>
+				<b uxa:md=label>
 			
 export tag IconButton < Button
+
+export tag LinkButton < a
+	prop icon
+	prop label
+
+	def render
+		<self.uxa.Button>
+			if icon
+				<Icon[icon]>
+			if label
+				<b uxa:md=label>

--- a/src/index.imba
+++ b/src/index.imba
@@ -1,7 +1,7 @@
 import Stack from './Stack'
 import Menu from './Menu'
 import MenuItem from './MenuItem'
-import Button,IconButton from './Button'
+import Button,IconButton,LinkButton from './Button'
 import TextField,TextArea,SelectField from './TextField'
 import ListItem from './ListItem'
 import Popover from './Popover'
@@ -126,6 +126,7 @@ extend class Imba.Event
 export var UXA = UXAWrapper.new(null)
 export var Button = Button
 export var IconButton = IconButton
+export var LinkButton = LinkButton
 export var Menu = Menu
 export var MenuItem = MenuItem
 export var TextField = TextField


### PR DESCRIPTION
The HTML5 spec says that a button must not have any "interactive content
descendant". This includes <a>-tags. This commit introduces a new tag,
LinkButton, which has the same styling as a Button, but is a <a> instead
of <button>.

LinkButton does not support `action` since it's supposed to only be used
for actual links.