### PR TITLE
Stack: Don't error when an Overlay is hidden twice

### DIFF
--- a/src/Stack.imba
+++ b/src/Stack.imba
@@ -29,6 +29,9 @@ export tag Overlay
 		self
 
 	def hide
+		return if @isHidden
+		@isHidden = yes
+
 		flag('uxa-hide')
 		component.flag('uxa-hide')
 		unflag('uxa-show')


### PR DESCRIPTION
It is possible to trigger `hide` twice (e.g. double tapping on the
backdrop).